### PR TITLE
feat: add UUID producer, corresponding tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Following is the table about all the pre-installed value producers:
 | @base64    | produces a base64 string |
 | @iso8601   | produces a ISO8601 string |
 | @cat       | used for concatenating strings |
+| @uuid      | produces a UUID string |
 
 ### Value producers with a single parameter
 <table><tr><th width="600">Template</th><th width="50%">Generated Json</th></tr>

--- a/src/main/java/com/github/jsontemplate/valueproducer/UuidValueProducer.java
+++ b/src/main/java/com/github/jsontemplate/valueproducer/UuidValueProducer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jsontemplate.valueproducer;
+
+import com.github.jsontemplate.jsonbuild.JsonStringNode;
+import com.github.jsontemplate.valueproducer.AbstractValueProducer;
+
+import java.util.UUID;
+
+/**
+ * This class produces a {@link JsonStringNode} which generates a UUID.
+ */
+public class UuidValueProducer extends AbstractValueProducer<JsonStringNode> {
+
+    /**
+     * The type name used in the template, e.g. {aUuidField: @uuid}
+     */
+    public static final String TYPE_NAME = "uuid";
+
+    @Override
+    public String getTypeName() {
+        return TYPE_NAME;
+    }
+
+    /**
+     * Produces a node which can generate a random UUID
+     *
+     * @return the produced json string node
+     */
+    @Override
+    public JsonStringNode produce() {
+        return new JsonStringNode(this::produceRandomUuid);
+    }
+
+    /**
+     * Produces a random UUID
+     *
+     * @return UUID string
+     */
+    protected String produceRandomUuid() {
+        return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Produces a node which is based on a UUID-string
+     *
+     * @return the produced json string node
+     */
+    @Override
+    public JsonStringNode produce(String value) {
+        return new JsonStringNode(() -> produceUuid(value));
+    }
+
+    /**
+     * Produces a UUID based on a UUID-string
+     *
+     * @return UUID string
+     */
+    protected String produceUuid(String value) {
+        return UUID.fromString(value).toString();
+    }
+}

--- a/src/test/java/com/github/jsontemplate/valueproducer/UuidValueProducerTest.java
+++ b/src/test/java/com/github/jsontemplate/valueproducer/UuidValueProducerTest.java
@@ -1,0 +1,30 @@
+package com.github.jsontemplate.valueproducer;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+
+public class UuidValueProducerTest {
+    private UuidValueProducer producer = new UuidValueProducer();
+
+    @Test
+    @DisplayName("generates a random UUID string")
+    void testProduce() {
+        String producedValue = producer.produce().compactString();
+        assertThat(producedValue, allOf(startsWith("\""), endsWith("\"")));
+    }
+
+    @Test
+    @DisplayName("generates a UUID based on a UUID string")
+    void testProduceWithSingleParam() {
+        String fixedValue = UUID.randomUUID().toString();
+        String producedValue = producer.produce(fixedValue).compactString();
+        assertThat(producedValue, allOf(startsWith("\""), endsWith("\"")));
+        assertThat(producedValue, is("\"" + fixedValue + "\""));
+    }
+}

--- a/src/test/resources/examples.txt
+++ b/src/test/resources/examples.txt
@@ -1,4 +1,18 @@
 ===== Template =====
+{aUuidField : @uuid}
+===== Generated Json =====
+{
+  "aUuidField" : "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+}
+
+===== Template =====
+{aUuidField: @uuid($myUuidValue)}
+===== Generated Json =====
+{
+  "aUuidField" : "f8c3de3d-1fea-4d7c-a8b0-29f63c4c3454"
+}
+
+===== Template =====
 {ipField : @ip}
 ===== Generated Json =====
 {


### PR DESCRIPTION
May I have this PR merged?
We at Statistics Norway are using your Json-templating library to transform arbitrary input data to Json. We need the possibility to generate UUIDs at transform time so that we do not another tool for the job.

Where are the missing Antlr-classes?



Great templating tool you have made.